### PR TITLE
Refactor(bintodec): using fold instead of a for

### DIFF
--- a/src/bintodec.rs
+++ b/src/bintodec.rs
@@ -1,15 +1,11 @@
 pub fn bi_to_dec(bin: String) -> String {
-    let bytes = bin.as_bytes();
-
-    let mut sum: usize = 0;
-
-    for (i, &char) in bytes.iter().enumerate() {
-        let inverted_pos = bin.chars().count() - (i + 1);
-
-        if char == b'1' {
-            sum += 2usize.pow(inverted_pos as u32);
-        }
-    }
+    let sum = bin.as_bytes()
+        .iter()
+        .enumerate()
+        .fold(0, |acc, (i, &b)| {
+            let inverted_pos = bin.len() - i - 1;
+            acc + if b == b'1' { 2usize.pow(inverted_pos as u32) } else { 0 }
+        });
 
     println!("the binary \"{bin}\" in decimal is: {sum}");
 


### PR DESCRIPTION
Refactored the bi_to_dec function in bintodec.rs to enhance readability and performance. Replaced a for loop with a fold operation for calculating the decimal value from a binary string.

You can apply the same approach to the rest of your functions. Consider avoiding the use of (mut, panic!, except, unwrap) in your code to further improve its readability and performance